### PR TITLE
Improve error messages when creating a flag

### DIFF
--- a/server/api/flags.js
+++ b/server/api/flags.js
@@ -58,8 +58,14 @@ const flags = {
     create: (object, options) => {
         // Todo: Add actual validation, shhh
 
-        return models.Flag.create(object).then(flag => {
-            return flag.toJSON();
+        return models.Flag.findOne({name: object.name}).then(flag => {
+            if (flag) {
+                throw new errors.ConflictError({message: 'flag name already exists'});
+            } else {
+                return models.Flag.create(object).then(flag => {
+                    return flag.toJSON();
+                });
+            }
         });
     },
 

--- a/server/errors.js
+++ b/server/errors.js
@@ -53,6 +53,12 @@ let errors = {
       statusCode: 401,
       errorType: 'UnauthorizedError'
     }, options));
+  },
+  ConflictError: function ConflictError(options) {
+    ScaffoldError.call(this, _.merge({
+      statusCode: 409,
+      errorType: 'ConflictError'
+    }, options));
   }
 };
 

--- a/server/web-console/controllers/flags.js
+++ b/server/web-console/controllers/flags.js
@@ -26,6 +26,10 @@ const flags = {
             req.flash('success', 'Flag created');
 
             return res.redirect('/flags');
+        }).catch(errors.ConflictError, (err) => {
+            req.flash('error', 'A flag with that name already exists!');
+
+            return res.redirect('/flags');
         }).catch(next);
     },
 

--- a/server/web-console/static/styles.css
+++ b/server/web-console/static/styles.css
@@ -62,9 +62,14 @@
     border-radius: 0.4rem;
 }
 
+.flash-container .flash.error {
+    border: 0.1rem solid #cea0a5;
+    background-color: #ffdce0;
+    color: #86181d;
+}
+
 .flash-container .flash p {
     margin: 0.3rem 0rem 0.3rem 0;
-    color: #9b4dca;
 }
 
 .flash-container .success {


### PR DESCRIPTION
* Check if the flag exists before creating it.
* If it exists, return a ConflictError (409) from the API.
* The web-console controller will then deliver this as an error message
and a redirect back to the flag list.

Also re-styled the “error” flash, still not overly happy with it though.