### PR TITLE
Add error messages to "add group to flag"

### DIFF
--- a/server/api/groups.js
+++ b/server/api/groups.js
@@ -58,7 +58,7 @@ const groups = {
                 if (!userIsInGroup(user, object.group_id)) {
                     user.groups.push(object.group_id);
                 } else {
-                    throw new errors.ValidationError({message: 'user is already a member of this group'});
+                    throw new errors.ConflictError({message: 'user is already a member of this group'});
                 }
 
                 const options = {

--- a/server/errors.js
+++ b/server/errors.js
@@ -16,10 +16,12 @@ function ScaffoldError(options) {
   // Defaults
   this.statusCode = 500;
   this.errorType = 'InternalServerError';
+  this.target = null;
 
   // Overrides
   this.statusCode = options.statusCode || this.statusCode;
   this.errorType = this.name = options.errorType || this.errorType;
+  this.target = options.target;
 
   this.message = options.message;
   this.hideStack = options.hideStack;

--- a/server/web-console/controllers/groups.js
+++ b/server/web-console/controllers/groups.js
@@ -54,7 +54,7 @@ const groups = {
                 req.flash('error', "That user doesn't exist");
 
                 res.redirect(`/groups/${object.group_id}/users/new`);
-            }).catch(errors.ValidationError, validationErr => {
+            }).catch(errors.ConflictError, validationErr => {
                 req.flash('error', "That user is already in this group");
 
                 res.redirect(`/groups/${object.group_id}/users/new`);


### PR DESCRIPTION
The following errors could appear if their criteria are met:

* Flag doesn’t exist
* Group doesn’t exist
* Group already has access to the flag.