### PR TITLE
Add a new error message to "edit flag"

### DIFF
--- a/server/api/flags.js
+++ b/server/api/flags.js
@@ -88,8 +88,6 @@ const flags = {
         return models.Flag.edit(object, options).then(flag => {
             if (flag) {
                 return flag.toJSON();
-            } else {
-                throw new errors.NotFoundError({message: 'flag not found'});
             }
         });
     },

--- a/server/models/base.js
+++ b/server/models/base.js
@@ -3,6 +3,7 @@ const schema = require('../data/schema').schema;
 const bookshelf = require('bookshelf')(db.knex);
 const ObjectId = require('bson-objectid');
 const _ = require('lodash');
+const errors = require('../errors');
 
 let BaseModel = require('bookshelf-modelbase')(bookshelf);
 
@@ -90,6 +91,8 @@ BaseModel = BaseModel.extend({
         return model.fetch(options).then(function then(object) {
             if (object) {
                 return object.save(data, options);
+            } else {
+                throw new errors.NotFoundError({message: 'model not found'});
             }
         });
     },

--- a/server/models/flag.js
+++ b/server/models/flag.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const base = require('./base').base;
 const registry = require('./base').registry;
 const modelUtils = require('./utils');
+const errors = require('../errors');
 
 let Flag = base.extend({
     tableName: 'flags',
@@ -70,6 +71,8 @@ let Flag = base.extend({
             }).then(function then() {
                 return self.findOne({id: flagId});
             });
+        }).catch(errors.NotFoundError, notFoundError => {
+            throw new errors.NotFoundError({message: 'flag not found'});
         });
     }
 });

--- a/server/web-console/controllers/flags.js
+++ b/server/web-console/controllers/flags.js
@@ -55,6 +55,10 @@ const flags = {
             req.flash('success', 'Successfully updated');
 
             res.redirect('/flags');
+        }).catch(errors.NotFoundError, notFoundError => {
+            req.flash('error', "That flag doesn't exist");
+
+            res.redirect('/flags');
         }).catch(next);
     },
 


### PR DESCRIPTION
If the flag is opened for editing, and then deleted by another user, hitting the “edit” button to save your changes would throw a 500 error. Now it returns an error flash saying the flag no longer exists.