### PR TITLE
Set the default population % to 0 for new flags

### DIFF
--- a/server/web-console/views/flags/new.hbs
+++ b/server/web-console/views/flags/new.hbs
@@ -39,7 +39,7 @@
                         <label for="populationPercentage">Population Percentage (optional)</label>
                     </dt>
                     <dd>
-                        <input id="population" class="form-control-small" name="population_percentage" type="number" min="0" step="1" max="100">
+                        <input id="population" class="form-control-small" name="population_percentage" type="number" min="0" step="1" max="100" value="0">
                         <p class="note">Incrementally roll out to a higher percentage of users as you desire. Set to 0 to turn this feature off.</p>
                     </dd>
                     <dd class="error" hidden>


### PR DESCRIPTION
On the "new" flag page, the population % was originally empty, it's now set to 0 by default to make the form valid with less user interaction.