### PR TITLE
Replace Staff group with Owner and Maintainer user permissions

### DIFF
--- a/server/api/web-session.js
+++ b/server/api/web-session.js
@@ -9,14 +9,15 @@ const webSession = {
         // Verify the user
         return models.User.verify(object).then(user => {
 
-            const userJson = user.toJSON();
+            user = user.toJSON();
             
-            const groups = _.map(userJson.groups, 'name');
-            const isStaff = _.includes(groups, 'staff');
+            const isMaintainer = user.is_maintainer;
+            const isOwner = user.is_owner;
 
             return {
                 userId: user.id,
-                isStaff: isStaff
+                isMaintainer: isMaintainer,
+                isOwner: isOwner
             };
         });
     }

--- a/server/data/schema/default-group.json
+++ b/server/data/schema/default-group.json
@@ -1,4 +1,0 @@
-{
-    "name": "staff",
-    "description": "Those with access to staff features and the web console"
-}

--- a/server/data/schema/schema.js
+++ b/server/data/schema/schema.js
@@ -3,6 +3,8 @@ const tables = {
         id: {type: 'string', nullable: false, primary: true},
         email: {type: 'string', maxlength: 254, nullable: false, unique: true},
         password: {type: 'string', maxlength: 60, nullable: false},
+        is_maintainer: {type: 'bool', defaultTo: false, nullable: false},
+        is_owner: {type: 'bool', defaultTo: false, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false}
     },

--- a/server/index.js
+++ b/server/index.js
@@ -6,8 +6,6 @@ function start() {
     console.log('models loaded');
 
     return settings.init().then(() => {
-        return models.Group.createDefault()
-    }).then(group => {
         return app = require('./app')();
     });
 }

--- a/server/middleware/locals.js
+++ b/server/middleware/locals.js
@@ -3,7 +3,10 @@ const api = require('../api');
 module.exports = function() {
     return function(req, res, next) {
         res.locals.isLoggedIn = !!req.session.userId;
-        res.locals.isStaff = !!req.session.isStaff;
+
+        // Owners can access everything a maintainer can
+        res.locals.isOwner = req.session.isOwner;
+        res.locals.isMaintainer = req.session.isMaintainer || req.session.isOwner;
 
         next();
     };

--- a/server/models/group.js
+++ b/server/models/group.js
@@ -9,19 +9,6 @@ let Group = base.extend({
         return this.belongsToMany('User');
     }
 }, {
-    createDefault: function createDefault() {
-        return this.count().then(numOfGroups => {
-            if (numOfGroups >= 1) {
-                return;
-            }
-
-            // No groups, lets create the staff group
-            let defaultGroup = require('../data/schema/default-group');
-            
-            return Group.forge(defaultGroup).save();
-        });
-    },
-
     findOne: function findOne(data, options) {
         options = options || {};
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -50,6 +50,9 @@ let User = base.extend({
             delete g._pivot_group_id;
         });
 
+        attributes.is_maintainer = !!attributes.is_maintainer;
+        attributes.is_owner = !!attributes.is_owner;
+
         return attributes;
     }
 }, {

--- a/server/web-console/controllers/sessions.js
+++ b/server/web-console/controllers/sessions.js
@@ -7,15 +7,15 @@ const sessionsController = {
     },
 
     create: (req, res, next) => {
-        api.webSession.create(req.body).then(userData => {
+        return api.webSession.create(req.body).then(userData => {
             req.session.userId = userData.userId;
-            req.session.isStaff = userData.isStaff;
+            req.session.isOwner = userData.isOwner;
+            req.session.isMaintainer = userData.isMaintainer;
+            
             req.flash('success', "Welcome back!");
 
             res.redirect('/');
         }).catch(errors.NotFoundError, errors.ForbiddenError, notFoundErr => {
-            // Don't tell the user if it's the password or email that is incorrect.
-            // Is this good practice?
             req.flash('error', "Your email address and password combination are incorrect.");
 
             res.redirect('/login');

--- a/server/web-console/controllers/users.js
+++ b/server/web-console/controllers/users.js
@@ -2,6 +2,10 @@ const api = require('../../api');
 const errors = require('../../errors');
 const settings = require('../../settings').cache;
 
+function convertCheckboxToBool(active) {
+    return (active !== 'undefined' && active === 'on');
+}
+
 const usersController = {
     index: (req, res, next) => {
         api.users.index().then(users => {
@@ -44,6 +48,23 @@ const usersController = {
             req.flash('error', 'It seems that email is already in use');
 
             res.redirect('/signup');
+        }).catch(next);
+    },
+
+    update: (req, res, next) => {
+        const updatedUser = req.body;
+        updatedUser.id = req.params.id;
+
+        updatedUser.is_owner = convertCheckboxToBool(updatedUser.is_owner);
+        updatedUser.is_maintainer = convertCheckboxToBool(updatedUser.is_maintainer);
+
+        return api.users.update(updatedUser, {id: updatedUser.id}).then(user => {
+            // Update the session
+            req.session.isMaintainer = user.is_maintainer;
+            req.session.isOwner = user.is_owner;
+
+            req.flash('success', 'User successfuly updated');
+            return res.redirect(`/users/${user.id}`);
         }).catch(next);
     }
 };

--- a/server/web-console/routes.js
+++ b/server/web-console/routes.js
@@ -1,39 +1,41 @@
 const express = require('express');
 const controllers = require('./controllers');
 const middleware = require('../middleware');
-const staffOnly = middleware.webAuth.staffOnly;
+
+const maintainerOnly = middleware.webAuth.maintainerOnly;
+const ownerOnly = middleware.webAuth.ownersOnly;
 
 const frontendRoutes = function frontendRoutes() {
     let router = express.Router();
     
     router.get('/signup', controllers.users.new);
     router.post('/signup', controllers.users.create);
-
-    router.get('/users', staffOnly, controllers.users.index); // Staff only
-    router.get('/users/:id', staffOnly, controllers.users.show);
-
     router.get('/login', controllers.sessions.new);
     router.post('/login', controllers.sessions.create);
 
-    router.get('/logout', controllers.sessions.destroy); // Not restful but easier for a browser
+    router.get('/users', maintainerOnly, controllers.users.index);
+    router.get('/users/:id', maintainerOnly, controllers.users.show);
+    router.post('/users/:id', maintainerOnly, controllers.users.update);
 
-    router.get('/settings', staffOnly, controllers.settings.index);
-    router.put('/settings', staffOnly, controllers.settings.update);
+    router.get('/logout', controllers.sessions.destroy);
 
-    router.delete('/groups/:group_id/users/:user_id', staffOnly, controllers.groups.users.destroy);
-    router.get('/groups/:id/users/new', staffOnly, controllers.groups.users.new);
-    router.post('/groups/:id/users', staffOnly, controllers.groups.users.create);
-    router.get('/groups/:id', staffOnly, controllers.groups.show);
-    router.get('/groups', staffOnly, controllers.groups.index);
+    router.get('/settings', ownerOnly, controllers.settings.index);
+    router.put('/settings', ownerOnly, controllers.settings.update);
 
-    router.get('/flags', staffOnly, controllers.flags.index);
-    router.post('/flags', staffOnly, controllers.flags.create);
-    router.get('/flags/new', staffOnly, controllers.flags.new);
-    router.get('/flags/:id/edit', staffOnly, controllers.flags.edit);
-    router.post('/flags/:id', staffOnly, controllers.flags.update);
-    router.get('/flags/:id/groups/new', staffOnly, controllers.flags.groups.new);
-    router.post('/flags/:id/groups', staffOnly, controllers.flags.groups.create);
-    router.delete('/flags/:name', staffOnly, controllers.flags.destroy);
+    router.delete('/groups/:group_id/users/:user_id', maintainerOnly, controllers.groups.users.destroy);
+    router.get('/groups/:id/users/new', maintainerOnly, controllers.groups.users.new);
+    router.post('/groups/:id/users', maintainerOnly, controllers.groups.users.create);
+    router.get('/groups/:id', maintainerOnly, controllers.groups.show);
+    router.get('/groups', maintainerOnly, controllers.groups.index);
+
+    router.get('/flags', maintainerOnly, controllers.flags.index);
+    router.post('/flags', maintainerOnly, controllers.flags.create);
+    router.get('/flags/new', maintainerOnly, controllers.flags.new);
+    router.get('/flags/:id/edit', maintainerOnly, controllers.flags.edit);
+    router.post('/flags/:id', maintainerOnly, controllers.flags.update);
+    router.get('/flags/:id/groups/new', maintainerOnly, controllers.flags.groups.new);
+    router.post('/flags/:id/groups', maintainerOnly, controllers.flags.groups.create);
+    router.delete('/flags/:name', maintainerOnly, controllers.flags.destroy);
 
     router.get('/terms', controllers.infoPages.terms);
     router.get('/', controllers.infoPages.index);

--- a/server/web-console/views/partials/nav.hbs
+++ b/server/web-console/views/partials/nav.hbs
@@ -4,7 +4,7 @@
             <a class="navigation-title" href="/">{{siteName}}</a>
             <ul class="navigation-list float-right">
                 {{#if isLoggedIn}}
-                    {{#if isStaff}}
+                    {{#if isMaintainer}}
                         <li class="navigation-item">
                             <a class="navigation-link" href="/users">Users</a>
                         </li>
@@ -14,9 +14,11 @@
                         <li class="navigation-item">
                             <a class="navigation-link" href="/flags">Flags</a>
                         </li>
-                        <li class="navigation-item">
-                            <a class="navigation-link" href="/settings">Settings</a>
-                        </li>
+                        {{#if isOwner}}
+                            <li class="navigation-item">
+                                <a class="navigation-link" href="/settings">Settings</a>
+                            </li>
+                        {{/if}}
                         <li class="navigation-item">
                             <a class="navigation-link" href="https://github.com/BlueHatbRit/scaffold/wiki">Docs</a>
                         </li>

--- a/server/web-console/views/users/show.hbs
+++ b/server/web-console/views/users/show.hbs
@@ -4,30 +4,65 @@
     {{> flash}}
     <div class="row">
         <div class="column">
-            <h1>User</h1>
-            <div id="show-user">
-                <label for="email">Email</label>
-                <input id="email" name="email" type="text" value="{{email}}" disabled>
+            <h1>Edit user</h1>
+            <form method="POST" action="/users/{{id}}" id="user">
 
-                <div>
-                    <h2>Groups</h2>
-                    <table>
-                        <thead>
+                <dl class="form-group">
+                    <dt class="input-label">
+                        <label for="email">Email Address</label>
+                    </dt>
+                    <dd>
+                        <input id="email" name="email" type="email" value={{email}} disabled>
+                    </dd>
+                </dl>
+
+                <dl class="form-group">
+                    <dd>
+                        {{#if isOwner}}
+                            <input type="checkbox" id="isMaintainer" name="is_maintainer" {{boolToCheckbox is_maintainer}}>
+                        {{else}}
+                            <input type="checkbox" id="isMaintainer" name="is_maintainer" {{boolToCheckbox is_maintainer}} disabled>
+                        {{/if}}
+                        <label for="isMaintainer" class="input-label label-inline">Maintainer</label>
+                        <p class="note">Maintainers can manage flags and groups.</p>
+                    </dd>
+                </dl>
+
+                <dl class="form-group">
+                    <dd>
+                        {{#if isOwner}}
+                            <input type="checkbox" id="isOwner" name="is_owner" {{boolToCheckbox is_owner}}>
+                        {{else}}
+                            <input type="checkbox" id="isOwner" name="is_owner" {{boolToCheckbox is_owner}} disabled>
+                        {{/if}}
+                        <label for="isOwner" class="input-label label-inline">Owner</label>
+                        <p class="note">Owners can make other users owners and maintainers.</p>
+                    </dd>
+                </dl>
+
+                {{#if isOwner}}
+                    <button type="submit">Save</button>
+                {{/if}}
+            </form>
+
+            <div>
+                <h2>Users groups</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{#each groups}}
                             <tr>
-                                <th>Name</th>
-                                <th>Description</th>
+                                <td><a href="/groups/{{id}}">{{name}}</a></td>
+                                <td>{{description}}</td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            {{#each groups}}
-                                <tr>
-                                    <td><a href="/groups/{{id}}">{{name}}</a></td>
-                                    <td>{{description}}</td>
-                                </tr>
-                            {{/each}}
-                        </tbody>
-                    </table>
-                </div>
+                        {{/each}}
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/test/integration/api/flags_spec.js
+++ b/test/integration/api/flags_spec.js
@@ -8,7 +8,6 @@ describe('Flags API', () => {
 
     beforeEach(utilities.teardownDb);
     beforeEach(utilities.initDb);
-    beforeEach(utilities.runApiInit);
 
     afterEach(utilities.teardownDb);
 

--- a/test/integration/api/sessions_spec.js
+++ b/test/integration/api/sessions_spec.js
@@ -13,7 +13,6 @@ describe('Sessions API', () => {
 
     beforeEach(utilities.teardownDb);
     beforeEach(utilities.initDb);
-    beforeEach(utilities.runApiInit);
     
     afterEach(utilities.teardownDb);
 

--- a/test/integration/api/users_spec.js
+++ b/test/integration/api/users_spec.js
@@ -7,7 +7,6 @@ describe('Users API', () => {
 
     beforeEach(utilities.teardownDb);
     beforeEach(utilities.initDb);
-    beforeEach(utilities.runApiInit);
 
     afterEach(utilities.teardownDb);
 
@@ -46,17 +45,16 @@ describe('Users API', () => {
             }).catch(done);
         });
 
-        it('if first user, add to staff group', done => {
+        it('if first user, make owner and maintainer', done => {
             let newUser = {
                 email: 'test@vintus.com',
                 password: 'supersecretpassword'
             };
 
             api.users.create(newUser).then(user => {
-                should.exist(user.groups);
-                user.groups.should.be.an.Array();
-                user.groups[0].name.should.equal('staff');
-
+                user.is_owner.should.be.a.Boolean();
+                user.is_maintainer.should.be.a.Boolean();
+                
                 done();
             }).catch(done);
         });

--- a/test/integration/api/web-sessions_spec.js
+++ b/test/integration/api/web-sessions_spec.js
@@ -9,12 +9,11 @@ describe('Web Sessions API', () => {
 
     beforeEach(utilities.teardownDb);
     beforeEach(utilities.initDb);
-    beforeEach(utilities.runApiInit);
     
     afterEach(utilities.teardownDb);
 
     describe('Log in', () => {
-        it('Returns the userId and isStaff status', done => {
+        it('Returns the session details status', done => {
             // Create a user account to log in with
             api.users.create(fixtures.user).then(user => {
 
@@ -23,8 +22,11 @@ describe('Web Sessions API', () => {
                     should.exist(userData.userId);
                     userData.userId.should.be.a.String();
 
-                    should.exist(userData.isStaff);
-                    userData.isStaff.should.be.a.Boolean();
+                    should.exist(userData.isOwner);
+                    userData.isOwner.should.be.a.Boolean();
+
+                    should.exist(userData.isMaintainer);
+                    userData.isMaintainer.should.be.a.Boolean();
 
                     done();
                 }).catch(done);

--- a/test/utilities/index.js
+++ b/test/utilities/index.js
@@ -28,20 +28,9 @@ let teardownDb = function teardown(done) {
     }
 };
 
-let runApiInit = function runApiInit(done) {
-    if (done) {
-        models.Group.createDefault().then(() => {
-            done();
-        }).catch(done);
-    } else {
-        return models.Group.createDefault();
-    }
-}
-
 module.exports = {
     initModels: initModels,
     initDb: initDb,
     teardownDb: teardownDb,
-    runApiInit: runApiInit,
     fixtures: require('./fixtures')
 };


### PR DESCRIPTION
Removed the default "staff" group, we now use an Owner and Maintainer toggle on specific users.

Gone through the entire app and ripped out the old staff group based auth and migrated over. This means groups can be a lot more flexible!